### PR TITLE
fixed key error if answer is not a-d

### DIFF
--- a/src/trivia_bot.py
+++ b/src/trivia_bot.py
@@ -40,9 +40,9 @@ class TriviaClient(discord.Client):
         result = False
         if answer.lower() == self.correct_answer.lower():
             result = True
-        elif self.answer_dict[answer.lower()].lower() == self.correct_answer.lower():
+        elif SequenceMatcher(None, answer, self.correct_answer).ratio() > 0.75:
             result = True
-        elif SequenceMatcher(answer, self.correct_answer).ratio() > 0.75:
+        elif answer.lower() in self.answer_dict.keys() and self.answer_dict[answer.lower()].lower() == self.correct_answer.lower():
             result = True
         return result
 


### PR DESCRIPTION
If the answer after !answer {} was not correct and was also not 'a', 'b', 'c', or 'd', this would throw a KeyError and crash the bot. Now it will check if the answer is in the keys() first and if not (and isn't correct based on the first two checks) it'll return false because at that point we know it's wrong.